### PR TITLE
feat: add a style for FormatStringToken

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -10,3 +10,6 @@ Metrics/ClassLength:
     - 'hash'
 Metrics/AbcSize:
   CountRepeatedAttributes: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template


### PR DESCRIPTION
```ruby
# Positional format sequences with field type characters
"Hi, my name is %s and I am %d years old. %0.1f to be exact." % ["John", 22, 22.45]

# Named format sequences without field type characters
"Hi, my name is %{name} and I am %{age} years old. %{precise_age} to be exact." % { name: "John", age: 22, precise_age: 22.45 }

# Named format sequences with field type characters
"Hi, my name is %<name>s and I am %<age>d years old. %<age>0.1f to be exact." % { name: "John", age:  22.45 }


# bad
format('%<greeting>s', greeting: 'Hello')
format('%s', 'Hello')

# good
format('%{greeting}', greeting: 'Hello')
```


