### PR TITLE
chore: add enum syntax cop for rails

### DIFF
--- a/rubocop_rails.yml
+++ b/rubocop_rails.yml
@@ -7,3 +7,6 @@ AllCops:
 
 Rails/SchemaComment:
   Enabled: true
+
+Rails/EnumSyntax:
+  Enabled: true


### PR DESCRIPTION
This is necessary because of the enums with keyword arguments will be deprecated in rails 8 in favor of positional ones.

DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead.